### PR TITLE
[Cache] Async Cache

### DIFF
--- a/src/Nuxed/Cache/Cache.hack
+++ b/src/Nuxed/Cache/Cache.hack
@@ -1,9 +1,8 @@
 namespace Nuxed\Cache;
 
-use namespace HH\Lib\Str;
+use namespace HH\Asio;
 use type Nuxed\Contract\Cache\CacheInterface;
 use type Nuxed\Contract\Cache\CacheExceptionInterface;
-use type Nuxed\Contract\Service\ResetInterface;
 use type Nuxed\Contract\Cache\CacheExceptionInterface;
 use type Nuxed\Contract\Cache\InvalidArgumentExceptionInterface;
 use type Nuxed\Contract\Log\LoggerInterface;
@@ -12,8 +11,7 @@ use type Nuxed\Contract\Log\LogLevel;
 use type Nuxed\Contract\Log\NullLogger;
 use type Exception;
 
-class Cache implements CacheInterface, ResetInterface, LoggerAwareInterface {
-
+final class Cache implements CacheInterface, LoggerAwareInterface {
   public function __construct(
     protected Store\StoreInterface $store,
     protected LoggerInterface $logger = new NullLogger(),
@@ -26,32 +24,42 @@ class Cache implements CacheInterface, ResetInterface, LoggerAwareInterface {
   /**
    * Determine if an item exists in the cache.
    */
-  public function contains(string $key): bool {
-    return $this->box(() ==> $this->store->contains(static::validateKey($key)));
+  public function contains(string $key): Awaitable<bool> {
+    return $this->box(
+      () ==> {
+        _Private\validate_key($key);
+        return $this->store->contains($key);
+      },
+    );
   }
 
   /**
    * Fetches a value from the cache.
    */
-  public function get(string $key, mixed $default = null): mixed {
-    return $this->box(
-      () ==> $this->store->contains(static::validateKey($key))
-        ? $this->store->get($key)
-        : $default,
-    );
+  public function get(string $key, mixed $default = null): Awaitable<mixed> {
+    return $this->box(async () ==> {
+      _Private\validate_key($key);
+      $exist = await $this->store->contains($key);
+      if ($exist) {
+        return await $this->store->get($key);
+      } else {
+        return $default;
+      }
+    });
   }
 
   /**
    * Retrieve a value from the cache and delete it.
    */
-  public function pull(string $key, mixed $default = null): mixed {
-    return $this->box(() ==> {
-      if (!$this->store->contains(static::validateKey($key))) {
+  public function pull(string $key, mixed $default = null): Awaitable<mixed> {
+    return $this->box(async () ==> {
+      $exist = await $this->contains($key);
+      if (!$exist) {
         return $default;
       }
 
-      $value = $this->store->get($key);
-      $this->store->delete($key);
+      $value = await $this->get($key);
+      await $this->forget($key);
       return $value;
     });
   }
@@ -59,118 +67,141 @@ class Cache implements CacheInterface, ResetInterface, LoggerAwareInterface {
   /**
    * Store an item in the cache.
    */
-  public function put(string $key, mixed $value, ?int $ttl = null): bool {
+  public function put(
+    string $key,
+    mixed $value,
+    ?int $ttl = null,
+  ): Awaitable<bool> {
     return $this->box(
-      () ==> $this->store->store(static::validateKey($key), $value, $ttl),
+      () ==> {
+        _Private\validate_key($key);
+        return $this->store->store($key, $value, $ttl);
+      },
     );
   }
 
   /**
    * Store an item in the cache if the key does not exist.
    */
-  public function add(string $key, mixed $value, ?int $ttl = null): bool {
-    return $this->box(() ==> {
-      if ($this->store->contains(static::validateKey($key))) {
+  public function add(
+    string $key,
+    mixed $value,
+    ?int $ttl = null,
+  ): Awaitable<bool> {
+    return $this->box(async () ==> {
+      $exist = await $this->contains($key);
+      if ($exist) {
         return false;
       }
 
-      return $this->store->store($key, $value, $ttl);
+      return await $this->put($key, $value, $ttl);
     });
   }
 
   /**
    * Increment the value of an item in the cache.
    */
-  public function increment(string $key, num $value = 1): bool {
-    $value = ($this->get(static::validateKey($key), 0) as num) + $value;
-    return $this->put($key, $value);
+  public async function increment(
+    string $key,
+    num $value = 1,
+  ): Awaitable<bool> {
+    $val = await $this->get($key, 0);
+    $val = ($val as num) + $value;
+    return await $this->put($key, $val);
   }
 
   /**
    * Decrement the value of an item in the cache.
    */
-  public function decrement(string $key, num $value = 1): bool {
+  public function decrement(string $key, num $value = 1): Awaitable<bool> {
     return $this->increment($key, $value * -1);
   }
 
   /**
    * Store an item in the cache indefinitely.
    */
-  public function forever(string $key, mixed $value): bool {
-    return $this->box(
-      () ==> $this->store->store(static::validateKey($key), $value, 0),
-    );
+  public function forever(string $key, mixed $value): Awaitable<bool> {
+    return $this->box(() ==> $this->put($key, $value, 0));
   }
 
   /**
    * Get an item from the cache, or execute the given Closure and store the result.
    */
-  public function remember(
+  public async function remember(
     string $key,
-    (function(): mixed) $callback,
+    (function(): Awaitable<mixed>) $callback,
     ?int $ttl = null,
-  ): mixed {
-    if ($this->contains(static::validateKey($key))) {
-      return $this->get($key);
+  ): Awaitable<mixed> {
+    $exist = await $this->contains($key);
+    if ($exist) {
+      return await $this->get($key);
     }
 
-    $value = $callback();
-    $this->put($key, $value, $ttl);
+    $value = await $callback();
+    await $this->put($key, $value, $ttl);
     return $value;
   }
 
   /**
    * Get an item from the cache, or execute the given Closure and store the result forever.
    */
-  public function sear(string $key, (function(): mixed) $callback): mixed {
-    if ($this->contains(static::validateKey($key))) {
-      return $this->get($key);
+  public async function sear(
+    string $key,
+    (function(): Awaitable<mixed>) $callback,
+  ): Awaitable<mixed> {
+    $exist = await $this->contains($key);
+    if ($exist) {
+      return await $this->get($key);
     }
 
-    $value = $callback();
-    $this->forever($key, $value);
+    $value = await $callback();
+    await $this->forever($key, $value);
     return $value;
   }
 
   /**
    * Remove an item from the cache.
    */
-  public function forget(string $key): bool {
-    return $this->box(() ==> $this->store->delete(static::validateKey($key)));
+  public function forget(string $key): Awaitable<bool> {
+    return $this->box(() ==> {
+      _Private\validate_key($key);
+      return $this->store->delete($key);
+    });
   }
 
   /**
    * Sets a cache item to be persisted later.
    */
   public function defer(string $key, mixed $value, ?int $ttl = null): bool {
-    return $this->box(
-      () ==> $this->store->defer(static::validateKey($key), $value, $ttl),
+    return Asio\join(
+      $this->box(
+        async () ==> {
+          _Private\validate_key($key);
+          return $this->store->defer($key, $value, $ttl);
+        },
+      ),
     );
   }
 
   /**
    * Persists any deferred cache items.
    */
-  public function commit(): bool {
+  public function commit(): Awaitable<bool> {
     return $this->box(() ==> $this->store->commit());
   }
 
   /**
    * Wipes clean the entire cache's keys.
    */
-  public function clear(): bool {
+  public function clear(): Awaitable<bool> {
     return $this->box(() ==> $this->store->clear());
   }
 
-  public function reset(): void {
-    if ($this->store is ResetInterface) {
-      $this->store->reset();
-    }
-  }
-
-  protected function box<T>((function(): T) $fun): T {
+  protected async function box<T>(
+    (function(): Awaitable<T>) $fun,
+  ): Awaitable<T> {
     try {
-      return $fun();
+      return await $fun();
     } catch (Exception $e) {
 
       $level = LogLevel::ALERT;
@@ -191,25 +222,9 @@ class Cache implements CacheInterface, ResetInterface, LoggerAwareInterface {
     }
   }
 
-  /**
-   * Validates a cache key.
-   *
-   * @throws InvalidArgumentException When $key is not valid
-   */
+  <<__Deprecated("To be removed in 0.2")>>
   public static function validateKey(string $key): string {
-    if ('' === $key) {
-      throw new Exception\InvalidArgumentException(
-        'Cache key length must be greater than zero',
-      );
-    }
-    if (false !== \strpbrk($key, '{}()/\@:')) {
-      throw new Exception\InvalidArgumentException(
-        Str\format(
-          'Cache key "%s" contains reserved characters {}()/\@:',
-          $key,
-        ),
-      );
-    }
+    _Private\validate_key($key);
     return $key;
   }
 }

--- a/src/Nuxed/Cache/Store/NullStore.hack
+++ b/src/Nuxed/Cache/Store/NullStore.hack
@@ -4,49 +4,53 @@ class NullStore implements StoreInterface {
   /**
    * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
    */
-  public function store(string $_id, mixed $_value, ?num $_ttl = null): bool {
+  public async function store(
+    string $_id,
+    mixed $_value,
+    ?int $_ttl = null,
+  ): Awaitable<bool> {
     return false;
   }
 
   /**
    * Sets a cache item to be persisted later.
    */
-  public function defer(string $_id, mixed $_value, ?num $_ttl = null): bool {
+  public function defer(string $_id, mixed $_value, ?int $_ttl = null): bool {
     return false;
   }
 
   /**
    * Determines whether an item is present in the cache.
    */
-  public function contains(string $_id): bool {
+  public async function contains(string $_id): Awaitable<bool> {
     return false;
   }
 
   /**
    * Delete an item from the cache by its unique key.
    */
-  public function delete(string $_id): bool {
+  public async function delete(string $_id): Awaitable<bool> {
     return false;
   }
 
   /**
    * Fetches a value from the cache.
    */
-  public function get(string $_id): mixed {
+  public async function get(string $_id): Awaitable<mixed> {
     return null;
   }
 
   /**
    * Wipes clean the entire cache's keys.
    */
-  public function clear(): bool {
+  public async function clear(): Awaitable<bool> {
     return false;
   }
 
   /**
    * Persists any deferred cache items.
    */
-  public function commit(): bool {
+  public async function commit(): Awaitable<bool> {
     return false;
   }
 }

--- a/src/Nuxed/Cache/Store/StoreInterface.hack
+++ b/src/Nuxed/Cache/Store/StoreInterface.hack
@@ -4,35 +4,39 @@ interface StoreInterface {
   /**
    * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
    */
-  public function store(string $id, mixed $value, ?num $ttl = null): bool;
+  public function store<T>(
+    string $id,
+    T $value,
+    ?int $ttl = null,
+  ): Awaitable<bool>;
 
   /**
    * Sets a cache item to be persisted later.
    */
-  public function defer(string $id, mixed $value, ?num $ttl = null): bool;
+  public function defer<T>(string $id, T $value, ?int $ttl = null): bool;
 
   /**
    * Determines whether an item is present in the cache.
    */
-  public function contains(string $id): bool;
+  public function contains(string $id): Awaitable<bool>;
 
   /**
    * Delete an item from the cache by its unique key.
    */
-  public function delete(string $id): bool;
+  public function delete(string $id): Awaitable<bool>;
 
   /**
    * Fetches a value from the cache.
    */
-  public function get(string $id): mixed;
+  public function get(string $id): Awaitable<mixed>;
 
   /**
    * Wipes clean the entire cache's keys.
    */
-  public function clear(): bool;
+  public function clear(): Awaitable<bool>;
 
   /**
    * Persists any deferred cache items.
    */
-  public function commit(): bool;
+  public function commit(): Awaitable<bool>;
 }

--- a/src/Nuxed/Cache/private.hack
+++ b/src/Nuxed/Cache/private.hack
@@ -1,0 +1,27 @@
+namespace Nuxed\Cache\_Private;
+
+use namespace HH\Lib\Str;
+use namespace Nuxed\Cache\Exception;
+
+
+/**
+ * Validates a cache key.
+ *
+ * @throws InvalidArgumentException When $key is not valid
+ */
+function validate_key(string $key): void {
+  if ('' === $key) {
+    throw new Exception\InvalidArgumentException(
+      'Cache key length must be greater than zero',
+    );
+  }
+
+  foreach (vec['{', '}', '(', ')', '/', '\\', '@', ':'] as $c) {
+    if (Str\contains($key, $c)) {
+      throw new Exception\InvalidArgumentException(Str\format(
+        'Cache key "%s" contains reserved characters {}()/\@:',
+        $key,
+      ));
+    }
+  }
+}

--- a/src/Nuxed/Contract/Cache/CacheInterface.hack
+++ b/src/Nuxed/Contract/Cache/CacheInterface.hack
@@ -4,56 +4,67 @@ interface CacheInterface {
   /**
    * Determine if an item exists in the cache.
    */
-  public function contains(string $key): bool;
+  public function contains(string $key): Awaitable<bool>;
 
   /**
    * Fetches a value from the cache.
    */
-  public function get(string $key, mixed $default = null): mixed;
+  public function get(string $key, mixed $default = null): Awaitable<mixed>;
 
   /**
    * Retrieve a value from the cache and delete it.
    */
-  public function pull(string $key, mixed $default = null): mixed;
+  public function pull(string $key, mixed $default = null): Awaitable<mixed>;
 
   /**
    * Store an item in the cache.
    */
-  public function put(string $key, mixed $value, ?int $ttl = null): bool;
+  public function put(
+    string $key,
+    mixed $value,
+    ?int $ttl = null,
+  ): Awaitable<bool>;
 
   /**
    * Store an item in the cache if the key does not exist.
    */
-  public function add(string $key, mixed $value, ?int $ttl = null): bool;
+  public function add(
+    string $key,
+    mixed $value,
+    ?int $ttl = null,
+  ): Awaitable<bool>;
 
   /**
    * Increment the value of an item in the cache.
    */
-  public function increment(string $key, num $value = 1): bool;
+  public function increment(string $key, num $value = 1): Awaitable<bool>;
 
   /**
    * Decrement the value of an item in the cache.
    */
-  public function decrement(string $key, num $value = 1): bool;
+  public function decrement(string $key, num $value = 1): Awaitable<bool>;
 
   /**
    * Store an item in the cache indefinitely.
    */
-  public function forever(string $key, mixed $value): bool;
+  public function forever(string $key, mixed $value): Awaitable<bool>;
 
   /**
    * Get an item from the cache, or execute the given Closure and store the result.
    */
   public function remember(
     string $key,
-    (function(): mixed) $callback,
+    (function(): Awaitable<mixed>) $callback,
     ?int $ttl = null,
-  ): mixed;
+  ): Awaitable<mixed>;
 
   /**
    * Get an item from the cache, or execute the given Closure and store the result forever.
    */
-  public function sear(string $key, (function(): mixed) $callback): mixed;
+  public function sear(
+    string $key,
+    (function(): Awaitable<mixed>) $callback,
+  ): Awaitable<mixed>;
 
   /**
    * Sets a cache item to be persisted later.
@@ -63,15 +74,15 @@ interface CacheInterface {
   /**
    * Persists any deferred cache items.
    */
-  public function commit(): bool;
+  public function commit(): Awaitable<bool>;
 
   /**
    * Remove an item from the cache.
    */
-  public function forget(string $key): bool;
+  public function forget(string $key): Awaitable<bool>;
 
   /**
    * Wipes clean the entire cache's keys.
    */
-  public function clear(): bool;
+  public function clear(): Awaitable<bool>;
 }

--- a/src/Nuxed/Http/Session/Persistence/CacheSessionPersistence.hack
+++ b/src/Nuxed/Http/Session/Persistence/CacheSessionPersistence.hack
@@ -1,5 +1,6 @@
 namespace Nuxed\Http\Session\Persistence;
 
+use namespace HH\Asio;
 use namespace HH\Lib\C;
 use namespace HH\Lib\Str;
 use type Nuxed\Contract\Http\Message\ServerRequestInterface;
@@ -55,8 +56,8 @@ class CacheSessionPersistence extends AbstractSessionPersistence {
     $id = $session->getId();
 
     if ($session->flushed()) {
-      if (!Str\is_empty($id)) {
-        $this->cache->contains($id) && $this->cache->forget($id);
+      if (!Str\is_empty($id) && Asio\join($this->cache->contains($id))) {
+        Asio\join($this->cache->forget($id));
       }
 
       return $this->flush($session, $response);
@@ -78,7 +79,7 @@ class CacheSessionPersistence extends AbstractSessionPersistence {
       $id = $this->regenerateSession($id);
     }
 
-    $this->cache->put($id, $session->items(), $session->age());
+    Asio\join($this->cache->put($id, $session->items(), $session->age()));
 
     return $this->withCacheHeaders(
       $response->withCookie(
@@ -96,8 +97,8 @@ class CacheSessionPersistence extends AbstractSessionPersistence {
    * Regardless, it generates and returns a new session identifier.
    */
   private function regenerateSession(string $id): string {
-    if (!Str\is_empty($id) && $this->cache->contains($id)) {
-      $this->cache->forget($id);
+    if (!Str\is_empty($id) && Asio\join($this->cache->contains($id))) {
+      Asio\join($this->cache->forget($id));
     }
     return $this->generateSessionId();
   }


### PR DESCRIPTION
this PR contains few changes, including BC breaks.

- fixes #17 
- remove function calls to php builtin
- deprecated `Cache::validateKey`
- add `_Private\validate_key` 
- remove `reset` implementation 
- always use `int` for expiration time.

